### PR TITLE
Remove comp-lzo from Client Config

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -240,7 +240,6 @@ persist-key
 persist-tun
 remote-cert-tls server
 cipher AES-256-CBC
-comp-lzo
 setenv opt block-outside-dns
 key-direction 1
 verb 3" > /etc/openvpn/client-common.txt


### PR DESCRIPTION
Remove comp-lzo from client config.

comp-lzo already removed from Server Configuration and it's a deprecated option.