### PR TITLE
Add support for additional data ciphers

### DIFF
--- a/openvpn-template.json
+++ b/openvpn-template.json
@@ -180,10 +180,10 @@
 			"type": "CustomScript",
 			"typeHandlerVersion": "2.0",
 			"autoUpgradeMinorVersion": true,
-			"settings": {
-				"fileUris": "[split('https://raw.githubusercontent.com/theonemule/simple-openvpn-server/master/openvpn.sh', ' ')]",
-				"commandToExecute": "[concat('bash openvpn.sh --host=', parameters('dnsNameForPublicIP'), '.', resourceGroup().location, '.cloudapp.azure.com --adminpassword=', parameters('adminPassword'), ' --email=', parameters('sslEmail'))]"
-			}
+      "settings": {
+        "fileUris": "[split('https://raw.githubusercontent.com/theonemule/simple-openvpn-server/master/openvpn.sh', ' ')]",
+        "commandToExecute": "[concat('bash openvpn.sh --host=', parameters('dnsNameForPublicIP'), '.', resourceGroup().location, '.cloudapp.azure.com --adminpassword=''', parameters('adminPassword'), ''' --email=''', parameters('sslEmail'), '''')]"
+      }
 		}
 	},	
     {

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -79,6 +79,12 @@ if [[ "$IP" = "" ]]; then
 fi
 
 
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+mkdir -p /var/lib/apt/lists/partial
+apt-get update
+apt-get install -y software-properties-common
+add-apt-repository -y universe
 apt-get update
 apt-get install openvpn iptables openssl fcgiwrap ca-certificates certbot python3-certbot-nginx apache2-utils nginx -y
 
@@ -88,7 +94,7 @@ if [[ -d /etc/openvpn/easy-rsa/ ]]; then
 fi
 # Get easy-rsa
 
-wget -O ~/EasyRSA-${VERSION}.tgz "https://github.com/OpenVPN/easy-rsa/releases/download/3.0.1/EasyRSA-${VERSION}.tgz"
+wget -O ~/EasyRSA-${VERSION}.tgz "https://github.com/OpenVPN/easy-rsa/releases/download/v${VERSION}/EasyRSA-${VERSION}.tgz"
 tar xzf ~/EasyRSA-${VERSION}.tgz -C ~/
 mv ~/EasyRSA-${VERSION}/ /etc/openvpn/
 mv /etc/openvpn/EasyRSA-${VERSION}/ /etc/openvpn/easy-rsa/
@@ -135,6 +141,8 @@ echo "push \"dhcp-option DNS $DNS1\"" >> /etc/openvpn/server.conf
 echo "push \"dhcp-option DNS $DNS2\"" >> /etc/openvpn/server.conf
 echo "keepalive 10 120
 cipher AES-256-CBC
+data-ciphers AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305:AES-256-CBC
+data-ciphers-fallback AES-256-CBC
 
 user nobody
 group $GROUPNAME
@@ -225,6 +233,8 @@ persist-key
 persist-tun
 remote-cert-tls server
 cipher AES-256-CBC
+data-ciphers AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305:AES-256-CBC
+data-ciphers-fallback AES-256-CBC
 setenv opt block-outside-dns
 key-direction 1
 verb 3" > /etc/openvpn/client-common.txt
@@ -274,7 +284,7 @@ htpasswd -b -c /etc/nginx/.htpasswd admin $ADMINPASSWORD
 
 #Obtain a Certificate from Let's Encrypt
 certbot run -d $HOST --agree-tos --nginx -m $EMAIL -n
-systemctl restart apache2
+#systemctl restart apache2
 
 #restart the web server
 systemctl restart nginx


### PR DESCRIPTION
Newer OpenVPN clients (or systems) only support latest data ciphers. These have been added to the configuration.

Additional changes:
- parameters have been quoted so weird characters do not break the command
- update apt
- fix the version in the OpenVPN GitHub URL